### PR TITLE
Fix for Dice Roll Bug

### DIFF
--- a/scripts/dnd-tools
+++ b/scripts/dnd-tools
@@ -815,7 +815,7 @@ def start_fn():
         sides = int(input("How many sides on each die? "))
         for _ in itertools.repeat(None, dice):
             print(random.randrange(1, sides))
-            start_fn()
+        start_fn()
     elif option == "3":
         n_players = int(input("How many initiative rolls (e.g. players + monsters)? "))
         for _ in itertools.repeat(None, n_players):


### PR DESCRIPTION
**Current Behavior** *entering multiple dice, still only results in one roll*:
```
$ dnd-tools 

        What would you like to do?          
        1) (C)reate Character / NPC         
        2) (R)oll Dice                      
        3) Roll Initiative (raw)            
        4) Encounter Experience Calculator  
        5) Get Treasure!                    
        6) Tarokka Fortune Cards            
        7) Wild Magic (Roll Effect)         
        0) (Q)uit                           

What would you like to do? 2
How many dice? 6
How many sides on each die? 20
12

        What would you like to do?          
        1) (C)reate Character / NPC         
        2) (R)oll Dice                      
        3) Roll Initiative (raw)            
        4) Encounter Experience Calculator  
        5) Get Treasure!                    
        6) Tarokka Fortune Cards            
        7) Wild Magic (Roll Effect)         
        0) (Q)uit                           

What would you like to do? 

```
**Fix**
in the dice roll block, the `start_fn()` call is indented and a part of the `for` block, so entering multiple dice has no effect