### PR TITLE
Update dnd-tools

### DIFF
--- a/scripts/dnd-tools
+++ b/scripts/dnd-tools
@@ -3235,7 +3235,7 @@ def modifiers_fn():
     print("The proficiency bonus for Lvl 1 characters is 2")
     print("Your class is: ", char_class)
     print("Calculating attack bonus...")
-    if char_class is "Barbarian":
+    if char_class == "Barbarian":
         prim_stat = "Strength"
     elif char_class in ("Bard", "Sorcerer", "Warlock"):
         prim_stat = "Charisma"
@@ -3823,7 +3823,7 @@ def skills_fn():
 def hp_fn():
     global char_hp
     print("Now we need to calculate hit points.")
-    if char_class is "Barbarian":
+    if char_class == "Barbarian":
         hit_die = random.randint(1, 12)
         char_hp = mod_con + hit_die
         print("You scored ", char_hp, " hit points")


### PR DESCRIPTION
/home/shinji/.local/bin/dnd-tools:3238: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if char_class is "Barbarian":
/home/shinji/.local/bin/dnd-tools:3826: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if char_class is "Barbarian":

Warning generated with Python 3.8 and higher.  This corrects it.  This could also be a consistency correction.